### PR TITLE
Added setup scripts for Windows and Linux. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ Follow this video tutorial
 
 Text Instructions:
 1. Download & Install Python
-2. Open Powershell and execute: ```pip install discord.py mss```. Or if you are in the repository folder, execute: ```pip install -r requirements.txt```
-3. Create a bot and get its token and then get your channel ID by following these instructions: https://github.com/Chikachi/DiscordIntegration/wiki/How-to-get-a-token-and-channel-ID-for-Discord
-4. Download the repository, edit local_credentials_example.py to insert the Bot Token and Channel ID and then rename the file to local_credentials.py
-5. Launch Chimera.py and visit the URL printed to the console to add Chimera to a personal channel
-6. Enjoy!
+2. Create a bot and get its token and then get your channel ID by following these instructions: https://github.com/Chikachi/DiscordIntegration/wiki/How-to-get-a-token-and-channel-ID-for-Discord
+3. Download the repository, run setup.bat(Windows) or setup.sh(Linux) and put your Bot Token in the newly created local_credentials.py. 
+4. Launch Chimera.py and visit the URL printed to the console to add Chimera to a personal channel
+5. Enjoy!
 
 
 

--- a/local_credentials_example.py
+++ b/local_credentials_example.py
@@ -1,4 +1,0 @@
-#copy this file into the same folder as chimera.py and rename the new file to local_credentials.py
-BOT_TOKEN = 'Enter Token Here'
-CHANNEL_ID = 'Enter Channel ID here'
-PYTHON_ALIAS = 'python' #only change if you have multiple python installations

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,19 @@
+@echo off
+
+echo Installing required packages.
+
+pip install -U -r .\requirements.txt
+
+echo Creating local_credentials.py
+
+echo BOT_TOKEN = 'Enter Token Here' > local_credentials.py
+
+echo. >> local_credentials.py
+
+echo CHANNEL_ID = 'Enter Channel ID here' >> local_credentials.py
+
+echo. >> local_credentials.py
+
+echo PYTHON_ALIAS = 'python' #only change if you have multiple python installations >> local_credentials.py
+
+echo Done. Please fill the required field in local_credentials.py

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ touch local_credentials.py
 
 printf "BOT_TOKEN = 'Enter Token Here'\n\n" > local_credentials.py
 
-printf "CHANNEL_ID = 'Enter Channel ID Here\n\n" >> local_credentials.py
+printf "CHANNEL_ID = 'Enter Channel ID Here'\n\n" >> local_credentials.py
 
 printf "PYTHON_ALIAS = 'python' #only change if you have multiple python installations" >> local_credentials.py
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+echo "Installing Required Packages..."
+
+pip3 install -U -r ./requirements.txt
+
+echo "Creating local_credentials.py..."
+
+touch local_credentials.py
+
+printf "BOT_TOKEN = 'Enter Token Here'\n\n" > local_credentials.py
+
+printf "CHANNEL_ID = 'Enter Channel ID Here\n\n" >> local_credentials.py
+
+printf "PYTHON_ALIAS = 'python' #only change if you have multiple python installations" >> local_credentials.py
+
+echo "Done. Please fill the required fields in local_credentials.py"


### PR DESCRIPTION
Now users and contributors can run `setup.bat/.sh` script and get everything set up for them. Script installs or upgrades the required python modules (from `requirements.txt`) and creates the `local_credentials.py`(this removes the need for having `local_credentials_example.py`). I updated the Text Instructions in `readme` to ilustrate the changes. 