### PR TITLE
Resolving icon.visible error and Discord Client Run Error

### DIFF
--- a/chimera.pyw
+++ b/chimera.pyw
@@ -3,6 +3,8 @@ import discord
 from discord.ext.commands import Bot
 import platform
 import os
+import asyncio
+from threading import Thread
 
 # Import configurations
 import configs
@@ -208,7 +210,11 @@ async def notification(ctx, txt):
 # System Tray menu functions
 
 # Starts the bot client
-def iconRun(icon): client.run(configs.BOT_TOKEN)
+def iconRun():
+    loop = asyncio.get_event_loop()
+    loop.create_task(client.start(configs.BOT_TOKEN))
+    t1=Thread(target=loop.run_forever)
+    t1.start()
 
 
 # Shows logs folder
@@ -252,10 +258,10 @@ def iconSetup():
         MenuItem("Exit", action=applicationExit),
     )
     icon = Icon('Chimera', icon=iconImage, menu=iconMenu)
-    icon.visible = True
     return icon
 
 
 # Application Entry Point - starts icon and bot client
 icon = iconSetup()
-icon.run(setup=iconRun)
+iconRun()
+icon.run()


### PR DESCRIPTION
* Solved an Attribute Error for Icon on Darwin by removing icon.visible: The icon is visible by default on new version the use of this command is deprecated and [removed from the instructions](https://github.com/moses-palmer/pystray/blob/master/docs/usage.rst) in the library (Creates confusion with the Icon.icon.visible attribute).
*   Solved an Error related to Discord Client Start. The command Client.run needs to be run from the main thread so it fails when run inside a setup function for Icon.run(setup=setup_fnc) giving:  
    >ValueError: set_wakeup_fd only works in main thread

This was solved by using an alternate method for Discord client connection on a separate Thread. **This method needs to be looked at further to allow the Thread to terminate when exiting via the icon menu!**