### PR TITLE
Resolve notification_module bug on macosx using native apple utility

### DIFF
--- a/modules/notification_module.py
+++ b/modules/notification_module.py
@@ -3,13 +3,18 @@
 # Usage: !notification "Notification Content"
 # Dependencies: plyer
 
+import os
 import asyncio
 from plyer import notification as notifier
-
+from plyer import utils as plyerUtils
 
 async def notification(ctx, txt):
     await ctx.send("Sending Notification: " + txt)
-    notifier.notify(title='Chimera Notification',
+    # Bypass plyer bug on macosx and use already included applescript
+    if plyerUtils.platform == 'macosx':
+        os.system("osascript -e 'display notification \"{}\"\'".format(txt))
+    else:
+        notifier.notify(title='Chimera Notification',
                     message=txt,
                     app_name="Chimera",
                     app_icon="icon.ico",


### PR DESCRIPTION
This references [a bug plyer has on macosx](https://github.com/kivy/plyer/issues/593).
It circumnavigates using the library by utilising a built in AppleScript so that notification module works properly on MacOS.